### PR TITLE
Make Pulumi dynamic resources more configurable

### DIFF
--- a/packages/cfs-pulumi/src/components/fargate.ts
+++ b/packages/cfs-pulumi/src/components/fargate.ts
@@ -44,6 +44,11 @@ export interface FargateArgs {
    * current aws account and region is used.
    */
   cluster?: Cluster;
+  /**
+   * HTTP port the Fargate service exposes. If none is provided, it defaults to
+   * 8080.
+   */
+  servicePort?: number;
 }
 
 export default class Fargate extends pulumi.ComponentResource {
@@ -55,6 +60,7 @@ export default class Fargate extends pulumi.ComponentResource {
       env,
       taskDefinitionArgs,
       cluster,
+      servicePort,
     } = args;
     super("aws:Fargate", name, args, opts);
     const domainParts = getDomainAndSubdomain(domain);
@@ -67,7 +73,7 @@ export default class Fargate extends pulumi.ComponentResource {
     )
       .createTargetGroup(
         `${name}-target-group`,
-        { port: 8080 },
+        { port: servicePort ?? 8080 },
         { parent: this }
       )
       .createListener(

--- a/packages/cfs-pulumi/src/providers/invalidateCloudfront.ts
+++ b/packages/cfs-pulumi/src/providers/invalidateCloudfront.ts
@@ -6,7 +6,13 @@ import AWS from "aws-sdk";
 // https://github.com/pulumi/pulumi-aws/issues/916
 
 export interface InvalidateCloudfrontResourceInputs {
+  /**
+   * The AWS ID of the CloudFront distribution.
+   */
   distributionId: pulumi.Input<string>;
+  /**
+   * An array of file paths to invalidate in CloudFront.
+   */
   paths: pulumi.Input<string[]>;
 }
 

--- a/packages/cfs-pulumi/src/providers/publishExpo.ts
+++ b/packages/cfs-pulumi/src/providers/publishExpo.ts
@@ -13,10 +13,33 @@ import { InputEnv } from "../common";
 // https://www.pulumi.com/docs/tutorials/aws/serializing-functions/#capturing-modules-in-a-javascript-function
 
 export interface PublishExpoResourceInputs {
+  /**
+   * Your expo username. Find by running `expo whoami`.
+   */
   username: pulumi.Input<string>;
+  /**
+   * Your expo password.
+   */
   password: pulumi.Input<string>;
+  /**
+   * The Expo release channel to publish the project to.
+   *
+   * See https://docs.expo.io/distribution/release-channels/
+   */
   releaseChannel: pulumi.Input<string>;
+  /**
+   * Path to the directory containing the mobile app's package.json. This dynamic
+   * provider assumes it contains a build command which it runs.
+   */
   mobilePath: pulumi.Input<string>;
+  /**
+   * An object containing environment variables to pass to the build.
+   *
+   * Ex.
+   * ```ts
+   * { MOBILE_APP_NAME: "My Mobile App" }
+   * ```
+   */
   env: InputEnv;
 }
 


### PR DESCRIPTION
- Configurable Fargate service port
- Configurable sync web build path (useful for paths beside `/build` like `/dist`)
- Docstrings on Pulumi dynamic provider inputs

Fixes #138 