### PR TITLE
Improve types in cfs-expo-auth0

### DIFF
--- a/packages/cfs-expo-auth0/package.json
+++ b/packages/cfs-expo-auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cfs-expo-auth0",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "Library for Auth0 React context for Expo in Create Full Stack.",
   "bugs": {
     "url": "https://github.com/tiagob/create-full-stack/issues"

--- a/packages/cfs-template-apollo-server-express-auth0/packages/mobile/package.json
+++ b/packages/cfs-template-apollo-server-express-auth0/packages/mobile/package.json
@@ -27,7 +27,7 @@
     "@react-navigation/drawer": "^5.9.0",
     "@react-navigation/native": "^5.7.3",
     "@unimodules/core": "~5.5.0",
-    "cfs-expo-auth0": "^0.1.1",
+    "cfs-expo-auth0": "^0.2.0",
     "common": "0.1.0",
     "expo": "^39.0.2",
     "expo-application": "~2.3.0",

--- a/packages/cfs-template-hasura-auth0/packages/mobile/package.json
+++ b/packages/cfs-template-hasura-auth0/packages/mobile/package.json
@@ -27,7 +27,7 @@
     "@react-navigation/drawer": "^5.9.0",
     "@react-navigation/native": "^5.7.3",
     "@unimodules/core": "~5.5.0",
-    "cfs-expo-auth0": "^0.1.1",
+    "cfs-expo-auth0": "^0.2.0",
     "common": "0.1.0",
     "expo": "^39.0.2",
     "expo-application": "~2.3.0",


### PR DESCRIPTION
There's a cleaner way to do the `result` types:
https://github.com/expo/expo/issues/10104#issuecomment-705559665